### PR TITLE
Change badge assignment logic for active incidents

### DIFF
--- a/src/geant_argus/geant_argus/templatetags/incident_extras.py
+++ b/src/geant_argus/geant_argus/templatetags/incident_extras.py
@@ -85,7 +85,9 @@ def incident_status_badge(incident: Incident):
     status = incident_status(incident)
     match status:
         case "Active":
-            return "badge-primary"
+            return level_to_badge(
+                incident.level, incident.metadata.get("status", "active").lower() != "closed"
+            )
         case "Clear":
             return "incident-clear"
         case "Stuck":


### PR DESCRIPTION
Change the colour of 'Active' to reflect the alarm severity